### PR TITLE
Allow for binary package name

### DIFF
--- a/src/depsolver_culprit.erl
+++ b/src/depsolver_culprit.erl
@@ -16,7 +16,6 @@
 
 -export_type([detail/0]).
 
--include_lib("eunit/include/eunit.hrl").
 %%============================================================================
 %% Types
 %%============================================================================
@@ -89,7 +88,6 @@ sort_constraints(State, Cons) ->
 -spec is_known(depsolver:dep_graph(), depsolver:constraint()) ->
                       boolean().
 is_known(State,  Con) ->
-  ?debugVal(Con),
     {PkgName, Vsn} = dep_pkg_vsn(Con),
     case gb_trees:lookup(PkgName, State) of
         none ->


### PR DESCRIPTION
I get a function_clause error when calling depsolver:solve.  Looks like dep_pkg_vsn doesn't match on a binary package name.  This fixes it, but it might not be the correct fix.  for review...

```
**error:function_clause

    chef_depsolver_tests: depsolver_impossible_dependency_test...*failed*
in function depsolver_culprit:dep_pkg_vsn/1 (src/depsolver_culprit.erl, line 127)
  called as dep_pkg_vsn(<<"foo">>)
in call from depsolver_culprit:is_known/2 (src/depsolver_culprit.erl, line 93)
in call from depsolver_culprit:'-sort_constraints/2-fun-0-'/4 (src/depsolver_culprit.erl, line 75)
in call from lists:foldl/3 (lists.erl, line 1197)
in call from depsolver_culprit:format_culprit_error/3 (src/depsolver_culprit.erl, line 65)
in call from depsolver:solve/2 (src/depsolver.erl, line 233)
in call from chef_depsolver_tests:depsolver_impossible_dependency_test/0 (test/chef_depsolver_tests.erl, line 153)
```
