### PR TITLE
Introduce solve/3 to expose timeout as part of public API

### DIFF
--- a/src/depsolver.app.src
+++ b/src/depsolver.app.src
@@ -3,7 +3,7 @@
 %%
 %% @author Eric Merritt <ericbmerritt@gmail.com>
 %%
-%% Copyright 2012 Opscode, Inc. All Rights Reserved.
+%% Copyright 2012-2013 Opscode, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file
@@ -22,7 +22,7 @@
 
 {application, depsolver,
  [{description, "Package Constraint Solver"},
-  {vsn, "1.0.0"},
+  {vsn, "1.1.0"},
   {modules, []},
   {mod, {depsolver_app, []}},
   {applications, [kernel, stdlib]}]}.

--- a/src/depsolver.erl
+++ b/src/depsolver.erl
@@ -83,6 +83,7 @@
          format_version/1,
          new_graph/0,
          solve/2,
+         solve/3,
          add_packages/2,
          add_package/3,
          add_package_version/3,
@@ -236,13 +237,19 @@ add_package_version({?MODULE, Dom0}, RawPkg, RawVsn, RawPkgConstraints) ->
 add_package_version(State, Pkg, Vsn) ->
     add_package_version(State, Pkg, Vsn, []).
 
-%% @doc Given a set of goals (in the form of constrains) find a set of packages
-%% and versions that satisfy all constraints. If no solution can be found then
-%% an exception is thrown.
+
+%% @doc Given a set of goals, in the form of constraints, find a set of packages
+%% and versions that satisfy all constraints. An error tuple is returned if no
+%% solution can be found or if solving takes longer than `Timeout' milliseconds.
 %% ``` depsolver:solve(State, [{app1, "0.1", '>='}]).'''
+-spec solve(t(),[constraint()], non_neg_integer()) -> {ok, [pkg()]} | {error, term()}.
+solve({?MODULE, DepGraph0}, RawGoals = [_H|_T], Timeout) ->
+    depsolver_worker_sup:solve(DepGraph0, RawGoals, Timeout).
+
+%% @doc Same as {@link solve/3} but use a default timeout.
 -spec solve(t(),[constraint()]) -> {ok, [pkg()]} | {error, term()}.
-solve({?MODULE, DepGraph0}, RawGoals) when erlang:length(RawGoals) > 0 ->
-    depsolver_worker_sup:solve(DepGraph0, RawGoals, ?DEFAULT_TIMEOUT).
+solve(G, RawGoals) ->
+    solve(G, RawGoals, ?DEFAULT_TIMEOUT).
 
 do_solve(DepGraph0, RawGoals)
   when erlang:length(RawGoals) > 0 ->


### PR DESCRIPTION
I think it will be cleaner to keep the public api in the depsolver module rather than having clients call depsolver_worker_sup directly.
